### PR TITLE
feat: Update Electron to v36.3.1 and Jikan API to v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
   "devDependencies": {
     "babel-eslint": "^10.0.3",
     "cross-env": "^6.0.3",
-    "electron": "^8.1.1",
+    "electron": "36.3.1",
     "electron-builder": "^22.2.0",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.10.0",


### PR DESCRIPTION
I've updated your project dependencies and API usage:

- Electron updated from ^8.1.1 to 36.3.1 in package.json.
- Jikan API base URL updated from v3 to v4 in renderer/pages/season.js.

I've also addressed breaking changes for Jikan API v4:
- API path changed from /season/... to /seasons/...
- Anime list data access updated from response.anime to response.data.
- Access to airing_start field updated to anime.aired.from.
- Implemented basic pagination for the /seasons endpoint (fetches first 3 pages).

Regarding Electron breaking changes:
- I've confirmed the 'remote' module is not in use.
- I've noted 'contextIsolation: false' for future review.

For Testing & Build:
- I was unable to execute the application (yarn dev) due to environment limitations (missing display server).
- The initial build (yarn build) failed with ERR_OSSL_EVP_UNSUPPORTED. I had a planned fix (setting NODE_OPTIONS=--openssl-legacy-provider) but was unable to apply it due to turn limit.

Here are the next steps:
- Apply the NODE_OPTIONS fix and attempt the build again.
- Conduct thorough testing in an environment with a display server.