### PR TITLE
feat: Display remaining time for downloads

### DIFF
--- a/main/functions.js
+++ b/main/functions.js
@@ -127,7 +127,8 @@ function startDownloading(
       bytes: 0,
       downloaded: torrent.downloaded,
       speed: torrent.downloadSpeed,
-      progress: torrent.progress
+      progress: torrent.progress,
+      timeRemaining: torrent.timeRemaining
     });
 
     torrent.on('download', function(bytes) {
@@ -136,7 +137,8 @@ function startDownloading(
         bytes,
         downloaded: torrent.downloaded,
         speed: torrent.downloadSpeed,
-        progress: torrent.progress
+        progress: torrent.progress,
+        timeRemaining: torrent.timeRemaining
       });
     });
 

--- a/renderer/components/video.js
+++ b/renderer/components/video.js
@@ -8,6 +8,30 @@ function bytesConverter(bytes) {
   return `${convertedValue}GB`;
 }
 
+function formatTimeRemaining(timeMillis) {
+  if (timeMillis === undefined || timeMillis === null || timeMillis <= 0) {
+    return "";
+  }
+
+  if (timeMillis < 60000) {
+    return "less than a minute remaining";
+  }
+
+  const minutes = Math.floor(timeMillis / 60000);
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+
+  if (hours === 0) {
+    return `${minutes}m remaining`;
+  }
+
+  if (remainingMinutes === 0) {
+    return `${hours}h remaining`;
+  }
+
+  return `${hours}h ${remainingMinutes}m remaining`;
+}
+
 export default class video extends Component {
   constructor(props) {
     super(props);
@@ -63,6 +87,9 @@ export default class video extends Component {
               </span>
               <span>
                 {bytesConverter(this.props.torrent[this.props.ep.magnet].speed)}
+              </span>
+              <span>
+                {formatTimeRemaining(this.props.torrent[this.props.ep.magnet].timeRemaining)}
               </span>
             </div>
           ) : null}


### PR DESCRIPTION
This commit implements the display of remaining download time for torrents.

Changes include:
- Modified `main/functions.js` to include `torrent.timeRemaining` in the `torrent-progress` IPC message payload.
- Updated `renderer/components/video.js` to:
  - Receive `timeRemaining` via props.
  - Add a helper function `formatTimeRemaining` to convert milliseconds into a human-readable string (e.g., "1h 23m remaining").
  - Display the formatted remaining time within the download progress UI.

The remaining time is now shown next to the download speed and updates dynamically as the download progresses.